### PR TITLE
[fix] fix router match regexp error on windows.

### DIFF
--- a/src/utils/filesys.ts
+++ b/src/utils/filesys.ts
@@ -99,7 +99,7 @@ export const matchPath = (
 
     const route = fileToRoute(file.rel);
 
-    if (match(route, requestPath).matches) {
+    if (match(route.replace(/\\/g, '/'), requestPath).matches) {
       return file;
     }
   }


### PR DESCRIPTION
tested on windows 10 and ubuntu 22.04